### PR TITLE
Fixed exceptions in loading geotif and applying cirus cloud mask

### DIFF
--- a/pymasker/landsatmasker.py
+++ b/pymasker/landsatmasker.py
@@ -35,7 +35,7 @@ class landsatmasker(masker):
 		mask = self.__masking(14, 3, conf, cumulative)
 
 		if cirrus:
-			mask = self.__masking2(msk, 12, 3, conf, False, cumulative)
+			mask = self.__masking2(mask, 12, 3, conf, False, cumulative)
 
 		return mask.astype(int)
 

--- a/pymasker/masker.py
+++ b/pymasker/masker.py
@@ -5,7 +5,7 @@ class masker:
 	'''Provides access to functions that produces masks from remote sensing image, according to its bit structure.'''
 
 	def __init__(self, band, *var):
-
+		
 		if type(band) is str:
 			if len(var) > 0:
 				self.loadfile(band, var[0])
@@ -33,7 +33,7 @@ class masker:
 			self.bandarray = gdal.Open(subdataset).ReadAsArray()
 		else:
 			bandfile = gdal.Open(filename)
-			self.bandarray = self.bandfile.GetRasterBand(1).ReadAsArray()
+			self.bandarray = bandfile.GetRasterBand(1).ReadAsArray()
 
 	def loadarray(self, array):
 		'''Load the BQA ban from a np.array


### PR DESCRIPTION
This fixes two issues I found when running this code...  stack traces from the errors are below.

Traceback (most recent call last):
  File "build_mask.py", line 7, in <module>
    masker = landsatmasker(lsname + "_BQA.TIF")
  File "/var/gis/working/pymasker/pymasker/masker.py", line 13, in __init__
    self.loadfile(band)
  File "/var/gis/working/pymasker/pymasker/masker.py", line 36, in loadfile
    self.bandarray = self.bandfile.GetRasterBand(1).ReadAsArray()

Traceback (most recent call last):
  File "build_mask.py", line 8, in <module>
    mask = masker.getcloudmask(confidence.medium, cirrus = True, cumulative = True)
  File "/var/gis/working/pymasker/pymasker/landsatmasker.py", line 38, in getcloudmask
    mask = self.__masking2(msk, 12, 3, conf, False, cumulative)
